### PR TITLE
Fix efficiency scaling for recipe cost calculations

### DIFF
--- a/database.py
+++ b/database.py
@@ -484,7 +484,7 @@ class Database:
         if efficiency <= 0:
             raise ValueError("Efficiency must be greater than 0")
 
-        multiplier = Decimal("100") / efficiency
+        multiplier = efficiency / Decimal("100")
         logger.info(
             "Рассчитываю стоимость рецепта '%s' с эффективностью %s", recipe_name, efficiency
         )


### PR DESCRIPTION
## Summary
- correct the efficiency multiplier so recipe material quantities scale down with lower efficiencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee676ed148320b09c62d50b8f5ce2