### PR TITLE
Add recipe autocomplete and shared database configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ export DISCORD_TOKEN=ВАШ_ТОКЕН
 # Для приватного репозитория GitHub (опционально):
 export GITHUB_USERNAME=ВАШ_ЛОГИН
 export GITHUB_TOKEN=ВАШ_PERSONAL_ACCESS_TOKEN
+# Путь к базе данных (опционально, позволяет использовать общую базу для нескольких серверов)
+export DATABASE_PATH=/srv/zavod/zavod.db
 ```
 
 ## Запуск


### PR DESCRIPTION
## Summary
- add autocomplete for the `/price` command powered by recipe names from the database
- forward startup notifications to the restart log channel so restart messages reach the log feed
- allow configuring a shared database path via `DATABASE_PATH` and document the new option

## Testing
- python -m compileall bot.py database.py

------
https://chatgpt.com/codex/tasks/task_e_68deea3ad510832095e5044ac1228dbb